### PR TITLE
[Dockerfile, YAML file, Readme] added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Let's see it in action.
 
 .. code-block:: bash
 
-  $ det http://domain.tld
+  $ docker-compose run --rm detectem http://domain.tld
   [{'name': 'phusion-passenger', 'version': '4.0.10'},
    {'name': 'apache-mod_bwlimited', 'version': '1.4'},
    {'name': 'apache-mod_fcgid', 'version': '2.3.9'},
@@ -37,42 +37,54 @@ There are two important articles to read:
 Features
 --------
 
-* Detect software in modern web technologies.
-* Browser support provided by Splash_.
-* Analysis on requests made and responses received by the browser.
-* Get software information from the DOM.
-* Great performance (less than 10 seconds to get a fingerprint).
-* Plugin system to add new software easily.
-* Test suite to ensure plugin result integrity.
-* Continuous development to support new features.
+* Detect software in modern web technologies
+* Browser support provided by Splash_
+* Analysis on requests made and responses received by the browser
+* Get software information from the DOM
+* Great performance (less than 10 seconds to get a fingerprint)
+* Plugin system to add new software easily
+* Test suite to ensure plugin result integrity
+* Continuous development to support new features
 
 
 Installation
 ------------
 
-1. Install Docker_ and add your user to the docker group, then you avoid to use sudo.
+1. Install the last `Docker CE Stable version`_
 
-2. Pull the image::
+2. Add your user into the docker group (this will avoid using sudo with docker)::
 
-    $ docker pull scrapinghub/splash
+    $ sudo usermod -a -G docker you
 
-3. Create a virtual environment with Python >= 3.5 .
+3. Install `Docker Compose`_
 
-4. Install detectem::
 
-    $ pip install detectem
+4. Download to your workspace the docker-compose building files
+    `Dockerfile-alternate`_
+    `docker-compose.yml`_
 
-5. Run it against some URL::
+5. Build the required docker images for Detectem::
+        
+    $ docker-compose up -d
 
-    $ det http://domain.tld
+    # This step will build up a Docker image for 'Splash' and another one for 'Python Alpine' which are necessaries as software dependencies for the Detectem container instances, so, let them survive. 
 
+    # Be patience, it will download 1.24GB
+
+6. Run Detectem against some URL::
+
+    $ docker-compose run --rm detectem url
+
+    # This will create a temporal Detectem container instance just to be executed against the target url 
 
 Documentation
 -------------
 
 The documentation is at `ReadTheDocs <https://detectem.readthedocs.io>`_.
 
-.. _Docker: http://docker.io
+.. _`Docker CE Stable version`: https://www.docker.com/community-edition
+.. _`Docker compose`: https://docs.docker.com/compose/install/
+.. _Dockerfile-alternate: https://github.com/alertot/detectem/tree/master/extras/docker/Dockerfile-alternate
+.. _docker-compose.yml: https://github.com/alertot/detectem/tree/master/extras/docker/docker-compose.yml
 .. _Splash: https://github.com/scrapinghub/splash
 .. _DOM: https://en.wikipedia.org/wiki/Document_Object_Model
-

--- a/extras/docker/Dockerfile-alternate
+++ b/extras/docker/Dockerfile-alternate
@@ -1,0 +1,10 @@
+FROM python:3.6.2-alpine3.6
+
+RUN apk add --update build-base libxml2-dev libxslt-dev
+
+RUN pip install bottle==0.12.13
+RUN pip install detectem
+
+USER nobody
+
+ENTRYPOINT ["det"]

--- a/extras/docker/docker-compose.yml
+++ b/extras/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+
+services:
+  splash:
+    image: scrapinghub/splash:3.0
+
+  detectem:
+    build: 
+      context: ./
+      dockerfile: Dockerfile-alternate
+    environment:
+      - SETUP_SPLASH=False
+      - SPLASH_URL=http://splash:8050
+    depends_on:
+      - splash


### PR DESCRIPTION
After investigating the different options to solve the dependency problem between Splash and Detectem, then Docker Compose was implemented concluding that it was elegant and clean considering all the trade-off with respect to the other ways of solution.

For this, a Docker mage of Splash and a Dockerfile (Dockerfile-alternate) were declared into the YAML file (docker-compose.yml) designed to build an Docker image for Detectem by Docker Compose.

Finally, the instructions to build the Docker image for Detectem were added into the README.rst